### PR TITLE
chore: gitignore agent rule symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ test-results/
 
 # TypeScript build info
 *.tsbuildinfo
+
+# Agent rule symlinks (point into ~/Projects/dotfiles)
+/AGENTS.md
+/AGENTS_INVARIANCE.md
+/docs/


### PR DESCRIPTION
## Summary
- Ignore `AGENTS.md`, `AGENTS_INVARIANCE.md`, and `docs/` — they're local symlinks into `~/Projects/dotfiles` for agent rules, not site content.
- Keeps `git status` clean on master.

## Test plan
- [x] `git status` shows clean working tree after ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)